### PR TITLE
dependabot/fetch-metadata@v1.1.1 is outdated

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@latest
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
With this version, I recieve security warning:

```
Warning:
The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files.
For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

log: https://github.com/neko314/pro-shogi-players/actions/runs/3977565098/jobs/6818804367

dependabot/fetch-metadata fixed at
https://github.com/dependabot/fetch-metadata/releases/tag/v1.3.5